### PR TITLE
Rand file must be in a selinux r/w folder for php.

### DIFF
--- a/vendor/phpseclib/phpseclib/phpseclib/openssl.cnf
+++ b/vendor/phpseclib/phpseclib/phpseclib/openssl.cnf
@@ -1,6 +1,6 @@
 # minimalist openssl.cnf file for use with phpseclib
 
 HOME			= .
-RANDFILE		= $ENV::HOME/.rnd
+RANDFILE		= /var/lib/php/.rnd
 
 [ v3_ca ]


### PR DESCRIPTION
Changes needed to use with SELinux.